### PR TITLE
feat: use clang-format's exported metadata.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,3 @@
 Language:        JavaScript
 BasedOnStyle:    Google
-ColumnLimit:     80
+ColumnLimit:     100

--- a/index.js
+++ b/index.js
@@ -7,65 +7,48 @@ var through = require('through2');
 
 var errors = [];
 
-module.exports = {
-  /**
-   * Verifies that files are already in the format produced by clang-format.
-   * Prints a warning to the console for any file which isn't formatted.
-   * @param {?(string|Object)} opt_options the string 'file' to search for a
-   * '.clang-format' file, or an object literal containing clang-format options
-   * http://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options
-   */
-  checkFormat: function(opt_options) {
-    var optsStr = opt_options || {BasedOnStyle: 'Google'};
-    if (typeof optsStr === 'object') {
-      optsStr = JSON.stringify(optsStr);
-    }
-
-    return through.obj(
-        function(file, enc, done) {
-          var actualStream =
-              file.isStream() ? file.content :
-                                fs.createReadStream(file.path, {encoding: enc});
-          var expectedStream = clangFormat(file, enc, optsStr, done);
-          streamEqual(actualStream, expectedStream, function(err, equal) {
-            if (err) {
-              return done(err);
-            }
-            if (!equal) {
-              errors.push(file.path);
-            }
-            done();
-          });
-        },
-        function(cb) {
-          if (errors.length > 0) {
-            // Avoid version skew between the version installed under
-            // gulp-clang-format and any
-            // version that was installed globally
-            var clangFormatBin =
-                './node_modules/gulp-clang-format/node_modules/clang-format/index.js';
-            gutil.log('WARNING: Files are not properly formatted. Please run');
-            gutil.log('  ' + clangFormatBin + ' -i -style="' + optsStr + '" ' +
-                      errors.join(' '));
-            gutil.log('  (using clang-format version ' + getClangFormatVersion() + ')');
-            this.emit('warning', new gutil.PluginError('gulp-clang-format',
-                                                       'files not formatted'));
-          }
-          cb();
-        });
+/**
+ * Verifies that files are already in the format produced by clang-format.
+ * Prints a warning to the console for any file which isn't formatted.
+ *
+ * @param {(string|Object)=} opt_options the string 'file' to search for a
+ *     '.clang-format' file, or an object literal containing clang-format options
+ *     http://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options
+ * @param {Object=} opt_clangFormat A clang-format module to optionally use.
+ */
+function checkFormat(opt_options, opt_clangFormat) {
+  var optsStr = opt_options || {BasedOnStyle: 'Google'};
+  var actualClangFormat = opt_clangFormat || clangFormat;
+  if (typeof optsStr === 'object') {
+    optsStr = JSON.stringify(optsStr);
   }
-};
 
-function getClangFormatVersion() {
-  var pkg;
-  var cf = require.resolve('clang-format');
-  var cfPath = cf;
-  while ((cfPath = path.dirname(cfPath)) !== '/') {
-    pkg = path.join(cfPath, 'package.json');
-    if (fs.existsSync(pkg)) {
-      var content = JSON.parse(fs.readFileSync(pkg, 'utf-8'));
-      return content['version'];
-    }
+  function filter(file, enc, done) {
+    var actualStream =
+        file.isStream() ? file.content : fs.createReadStream(file.path, {encoding: enc});
+    var expectedStream = actualClangFormat(file, enc, optsStr, done);
+    streamEqual(actualStream, expectedStream, function(err, equal) {
+      if (err) {
+        return done(err);
+      }
+      if (!equal) {
+        errors.push(file.path);
+      }
+      done();
+    });
   }
-  throw new Error('Could not find clang-format version for ' + cf);
+
+  function onError(cb) {
+    if (errors.length > 0) {
+      var clangFormatBin = './' + path.relative(process.cwd(), clangFormat.location);
+      gutil.log('WARNING: Files are not properly formatted. Please run');
+      gutil.log('  ' + clangFormatBin + ' -i -style="' + optsStr + '" ' + errors.join(' '));
+      gutil.log('  (using clang-format version ' + clangFormat.version + ')');
+      this.emit('warning', new gutil.PluginError('gulp-clang-format', 'files not formatted'));
+    }
+    cb();
+  }
+  return through.obj(filter, onError);
 }
+
+exports.checkFormat = checkFormat;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gulp": "^3.8.11"
   },
   "dependencies": {
-    "clang-format": "^1.0.17",
+    "clang-format": "^1.0.24",
     "gulp-util": "^3.0.4",
     "pkginfo": "^0.3.0",
     "stream-equal": "^0.1.5",


### PR DESCRIPTION
This gives a much more stable and less awkward interface between `clang-format` and `gulp-clang-format`.
