### PR TITLE
fix: log relative path instead of full absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function checkFormat(opt_clangOptions, opt_clangFormat, opt_gulpOptions) {
       pipe,
       through2({objectMode: true},
                function(f, enc, done) {
-                 if (f.diff && Object.keys(f.diff).length) filePaths.push(f.path);
+                 if (f.diff && Object.keys(f.diff).length) filePaths.push(path.relative(process.cwd(), f.path));
                  done(null, f);
                },
                function(done) {


### PR DESCRIPTION
At the moment when formatting issues occur absolute file paths are logged. When running in CI this is a bit of a problem as users need to go through all the paths and make them relative to their cwd.

This changes bring that files are always logged relative from `cwd`. 

**Before**
```bash
node_modules/clang-format/index.js -i -style="file" /home/circleci/ng/packages/language-service/src/ts_plugin.ts /home/circleci/ng/packages/compiler/test/template_parser/template_parser_spec.ts /home/circleci/ng/packages/compiler-cli/src/metadata/collector.ts /home/circleci/ng/packages/compiler-cli/src/transformers/lower_expressions.ts /home/circleci/ng/packages/compiler-cli/test/metadata/typescript.mocks.ts
```

**After**
```bash
node_modules/clang-format/index.js -i -style="file" packages/language-service/src/ts_plugin.ts packages/compiler/test/template_parser/template_parser_spec.ts packages/compiler-cli/src/metadata/collector.ts packages/compiler-cli/src/transformers/lower_expressions.ts packages/compiler-cli/test/metadata/typescript.mocks.ts

```